### PR TITLE
Include the required packages to setup.py

### DIFF
--- a/{{ cookiecutter.project_slug }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/setup.py
@@ -10,6 +10,39 @@ import re
 from setuptools import setup
 
 
+def load_requirements(*requirements_paths):
+    """
+    Load all requirements from the specified requirements files.
+    Returns a list of requirement strings.
+    """
+    requirements = set()
+    for path in requirements_paths:
+        requirements.update(
+            line.split('#')[0].strip() for line in open(path).readlines()
+            if is_requirement(line)
+        )
+    return list(requirements)
+
+
+def is_requirement(line):
+    """
+    Return True if the requirement line is a package requirement;
+    that is, it is not blank, a comment, or editable.
+    """
+    # Remove whitespace at the start/end of the line
+    line = line.strip()
+
+    # Skip blank lines, comments, and editable installs
+    return not (
+        line == '' or
+        line.startswith('-r') or
+        line.startswith('#') or
+        line.startswith('-e') or
+        line.startswith('git+') or
+        line.startswith('-c')
+    )
+
+
 def get_version(*file_paths):
     """
     Extract the version string from the file at the given relative path fragments.
@@ -33,14 +66,14 @@ setup(
     author='eduNEXT',
     author_email='contact@edunext.co',
     packages=[
-        '{{ cookiecutter.package_name }}'
+        '{{ cookiecutter.package_name }}',
     ],
     include_package_data=True,
-    install_requires=[],
+    install_requires=load_requirements('requirements/base.in'),
     zip_safe=False,
     entry_points={
         "lms.djangoapp": [
             '{{ cookiecutter.package_name }} = {{ cookiecutter.package_name }}.apps:{{ cookiecutter.class_name }}Config',
         ],
-    }
+    },
 )


### PR DESCRIPTION
## Description:

This PR adds the functionality to load the project requirements into setup.py, this is useful when installing the package in non-editable mode.

## Reviewers:

- [ ] @felipemontoya 