### PR TITLE
Add body to the changelog file

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,5 +2,6 @@
     "project_desc": "My Open edX Plugin",
     "package_name": "plugin_name",
     "project_slug": "{{ cookiecutter.package_name }}",
-    "class_name": "MyOpenEdxPlugin"
+    "class_name": "MyOpenEdxPlugin",
+    "version": "0.0.0"
 }

--- a/{{ cookiecutter.project_slug }}/CHANGELOG.rst
+++ b/{{ cookiecutter.project_slug }}/CHANGELOG.rst
@@ -1,0 +1,19 @@
+Change Log
+==========
+
+..
+   All enhancements and patches to {{ cookiecutter.package_name }} will be documented
+   in this file.  It adheres to the structure of http://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+   
+   This project adheres to Semantic Versioning (http://semver.org/).
+.. There should always be an "Unreleased" section for changes pending release.
+Unreleased
+----------
+
+*
+
+[{{ cookiecutter.version }}] - {% now 'local' %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.package_name }}/__init__.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.package_name }}/__init__.py
@@ -5,4 +5,4 @@ Init module for {{ cookiecutter.package_name }}.
 from __future__ import unicode_literals
 
 
-__version__ = '0.0.0'
+__version__ = '{{ cookiecutter.version }}'


### PR DESCRIPTION
This PRs adds to the cookiecutter a basic body to the changelog.

This is very important for the repos that we want to release on PYPI. I am adding this here first, in order to start the discussion.

It is basically a copy of https://github.com/edx/edx-cookiecutters/blob/master/python-template/%7B%7Bcookiecutter.placeholder_repo_name%7D%7D/CHANGELOG.rst

As it is described in the template.

`  It adheres to the structure of https://keepachangelog.com/ ,
   but in reStructuredText instead of Markdown`

You can see more details about the format in https://keepachangelog.com/en/1.0.0/

